### PR TITLE
Update reader_metadata.py to accept '.tif' and '.ome.tif' naming

### DIFF
--- a/bioio_ome_tiff/reader_metadata.py
+++ b/bioio_ome_tiff/reader_metadata.py
@@ -21,7 +21,7 @@ class ReaderMetadata(bioio_base.reader_metadata.ReaderMetadata):
         """
         Return a list of file extensions this plugin supports reading.
         """
-        return [".ome.tiff", ".tiff"]
+        return [".ome.tiff", ".tiff", "ome.tif", ".tif"]
 
     @staticmethod
     def get_reader() -> bioio_base.reader.Reader:


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests for your feature or bug fix.

  ❗️ Also: ❗️

  Please name your pull request {development-type}/{short-description}.
  For example: feature/read-tiff-files
-->

### Description of Changes

Add support for images with '.tif', and '.ome.tif' naming. Some naming conventions in my experience use a single 'f' ending, and this would support these files likely containing the same metadata as with double 'ff' endings. 

<!-- Include a description of the proposed changes. -->
