### PR TITLE
Avoid reading channels as samples if possible

### DIFF
--- a/bioio_ome_tiff/reader.py
+++ b/bioio_ome_tiff/reader.py
@@ -159,6 +159,16 @@ class Reader(reader.Reader):
         # not also found in OME will be omitted.
         dims_from_tiff_axes = list(tiff.series[scene_index].axes)
 
+        # If the OME metadata does not have a "S" dimension but the tiff axes
+        # does, and the OME metadata has a "C" dimension but the tiff axes does
+        # not, then we can assume that the "S" dimension in the tiff axes is
+        # actually the "C" dimension in the OME metadata.
+        if "S" in dims_from_tiff_axes and "S" not in dims_from_ome and "C" in dims_from_ome and "C" not in dims_from_tiff_axes:
+            dims_from_tiff_axes = [
+                dim if dim != "S" else "C"
+                for dim in dims_from_tiff_axes
+            ]
+
         # Adjust the guess of what the dimensions are based on the combined
         # information from the tiff axes and the OME metadata.
         # Necessary since while OME metadata should be source of truth, it

--- a/bioio_ome_tiff/reader.py
+++ b/bioio_ome_tiff/reader.py
@@ -163,10 +163,14 @@ class Reader(reader.Reader):
         # does, and the OME metadata has a "C" dimension but the tiff axes does
         # not, then we can assume that the "S" dimension in the tiff axes is
         # actually the "C" dimension in the OME metadata.
-        if "S" in dims_from_tiff_axes and "S" not in dims_from_ome and "C" in dims_from_ome and "C" not in dims_from_tiff_axes:
+        if (
+            "S" in dims_from_tiff_axes
+            and "S" not in dims_from_ome
+            and "C" in dims_from_ome
+            and "C" not in dims_from_tiff_axes
+        ):
             dims_from_tiff_axes = [
-                dim if dim != "S" else "C"
-                for dim in dims_from_tiff_axes
+                dim if dim != "S" else "C" for dim in dims_from_tiff_axes
             ]
 
         # Adjust the guess of what the dimensions are based on the combined

--- a/bioio_ome_tiff/utils.py
+++ b/bioio_ome_tiff/utils.py
@@ -599,11 +599,17 @@ def get_dims_from_ome(ome: OME, scene_index: int) -> List[str]:
     # Check for num samples and expand dims if greater than 1
     n_samples = scene_meta.pixels.channels[0].samples_per_pixel
     if n_samples is not None and n_samples > 1 and "S" not in dims:
-        # Append to the end, i.e. the last dimension
-        dims.append("S")
+        # The OME spec might be describing the channels as samples.
+        # If so, by checking if the channel length is the same length
+        # as the described samples, we need to add samples as the last dimension.
+        if len(scene_meta.pixels.channels) != n_samples:
+            dims.append("S")
+        else:
+            # If not, need to drop the channel dimension and add it in place of
+            # samples
+            dims = [dim for dim in dims if dim != "C"] + ["C"]
 
     return dims
-
 
 def get_coords_from_ome(
     ome: OME, scene_index: int

--- a/bioio_ome_tiff/utils.py
+++ b/bioio_ome_tiff/utils.py
@@ -611,6 +611,7 @@ def get_dims_from_ome(ome: OME, scene_index: int) -> List[str]:
 
     return dims
 
+
 def get_coords_from_ome(
     ome: OME, scene_index: int
 ) -> Dict[str, Union[List[Any], Union[types.ArrayLike, Any]]]:


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests for your feature or bug fix.

  ❗️ Also: ❗️

  Please name your pull request {development-type}/{short-description}.
  For example: feature/read-tiff-files
-->

### Link to Relevant Issue

This pull request resolves #13 

### Description of Changes

It seems the file's metadata has a Channels dimension being described as a Samples dimension by the OME metadata and so when bioio tries to read the file it tries to access a XYC shaped image as a XYS shaped image.

The hope of this changeset is that if we see an image that is described as having channels in the OME yet none according to the axes meanwhile having a samples dimension that the samples dimension is actually the channels dimension.

This changeset made the file readable for me. However, not totally sure I love the way I fixed this, very open to recommendations.
