### PR TITLE
Prevent install of breaking change version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
   "tifffile>=2022.4.22",
   "xarray>=0.16.1",
   "xmlschema",  # no pin because it's pulled in from OME types
-  "zarr>=2.6", # for tifffile
+  "zarr>=2.6,<3.0.0", # for tifffile
 ]
 
 [project.urls]


### PR DESCRIPTION
### Link to Relevant Issue

This pull request resolves # https://github.com/bioio-devs/bioio-ome-tiff/issues/16

### Description of Changes

Prevent install of zarr >= 3.0.0, which introduces a breaking change
