### PR TITLE
Feature/5 more tiff tags

### DIFF
--- a/bioio_ome_tiff/reader.py
+++ b/bioio_ome_tiff/reader.py
@@ -195,12 +195,12 @@ class Reader(reader.Reader):
 
         Returns
         -------
-            attrs: Dict[str, Any] 
+            attrs: Dict[str, Any]
                 the modified dictionary, with the unprocessed tags unpacked
         """
-        unprocessed = attrs[constants.METADATA_UNPROCESSED]
+        unprocessed = attrs[constants.METADATA_UNPROCESSED] if constants.METADATA_UNPROCESSED in attrs else {}
         if not unprocessed:
-            return unprocessed
+            return attrs
         for k, v in unprocessed.items():
             # also break up code 50839 which is where it seems MM metadata lives
             # 50839 is a private tag registered with Adobe
@@ -348,7 +348,7 @@ class Reader(reader.Reader):
             constants.METADATA_PROCESSED: self._ome,
         }
         attrs = self._unpack_unprocessed_tags(attrs)
-        
+
         return xr.DataArray(
             image_data,
             dims=dims,

--- a/bioio_ome_tiff/reader.py
+++ b/bioio_ome_tiff/reader.py
@@ -315,7 +315,7 @@ class Reader(reader.Reader):
             constants.METADATA_UNPROCESSED: tiff_tags,
             constants.METADATA_PROCESSED: self._ome,
         }
-        local_attrs = self._unpack_uprocessed_tags(attrs=local_attrs)
+        local_attrs = self._unpack_unprocessed_tags(attrs=local_attrs)
 
         return xr.DataArray(
             image_data,
@@ -325,7 +325,7 @@ class Reader(reader.Reader):
         )
 
     @staticmethod
-    def _unpack_uprocessed_tags(attrs: Dict[str, Any]) -> Dict[str, Any]:
+    def _unpack_unprocessed_tags(attrs: Dict[str, Any]) -> Dict[str, Any]:
         """unpack the 'unprocessed' tags for visibility in attrs dict
 
         Args:

--- a/bioio_ome_tiff/reader.py
+++ b/bioio_ome_tiff/reader.py
@@ -198,11 +198,15 @@ class Reader(reader.Reader):
             attrs: Dict[str, Any]
                 the modified dictionary, with the unprocessed tags unpacked
         """
-        unprocessed = attrs[constants.METADATA_UNPROCESSED] if constants.METADATA_UNPROCESSED in attrs else {}
+        unprocessed = (
+            attrs[constants.METADATA_UNPROCESSED]
+            if constants.METADATA_UNPROCESSED in attrs
+            else {}
+        )
         if not unprocessed:
             return attrs
         for k, v in unprocessed.items():
-            # also break up code 50839 which is where it seems MM metadata lives
+            # break up code 50839 which is where it seems MM metadata lives
             # 50839 is a private tag registered with Adobe
             if k == 50839:
                 try:

--- a/bioio_ome_tiff/tests/test_reader.py
+++ b/bioio_ome_tiff/tests/test_reader.py
@@ -499,6 +499,6 @@ def test_ome_metadata(filename: str) -> None:
         ),
     ],
 )
-def test_unpacking_uproccessed(attrs: dict, expected: dict) -> None:
-    actual = Reader._unpack_uprocessed_tags(attrs=attrs)
+def test_unpacking_unproccessed(attrs: dict, expected: dict) -> None:
+    actual = Reader._unpack_unprocessed_tags(attrs=attrs)
     assert actual == expected


### PR DESCRIPTION
### Link to Relevant Issue

This pull request resolves #
https://github.com/bioio-devs/bioio-ome-tiff/issues/5

### Description of Changes

If there is a dictionary of UNPROCESSED tags, surface them up one level as per historical request pulled over from AICSIMAGEIO.

Possibly this change should be propogated over to bioio-tifffile and bioio-tiff-glob as well, if it passes here.