### PR TITLE
feature/make-zarr-optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ Information about the base reader this package relies on can be found in the `bi
 
 **Stable Release:** `pip install bioio-ome-tiff`<br>
 **Development Head:** `pip install git+https://github.com/bioio-devs/bioio-ome-tiff.git`
+## Optional: Install with Zarr Support
+
+To enable more efficient chunked reading for large TIFF files using the Zarr interface, you can install `bioio-ome-tiff` with optional Zarr support.
+The reason this is optional is that it requires a legacy version of the `zarr` package which clashes with some of the existing reader plugins.
+```
+pip install "bioio-ome-tiff[zarr]"
+```
 
 ## Example Usage (see full documentation for more examples)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,9 +39,7 @@ dependencies = [
   "tifffile>=2022.4.22",
   "xarray>=0.16.1",
   "xmlschema",  # no pin because it's pulled in from OME types
-  #zarr pinned since breaking changes in 3.0 are available with python 3.11
-  "zarr>=2.6,<3.0.0", # for tifffile;
-]
+  ]
 
 [project.urls]
 Homepage = "https://github.com/bioio-devs/bioio-ome-tiff"
@@ -51,6 +49,9 @@ Homepage = "https://github.com/bioio-devs/bioio-ome-tiff"
 # extra dependencies
 # https://peps.python.org/pep-0621/#dependencies-optional-dependencies
 [project.optional-dependencies]
+zarr = [
+  "tifffile[zarr]>=2022.4.22",
+]
 lint = [
   "pre-commit>=2.20.0",
 ]


### PR DESCRIPTION
### Description 

Tifffile requires zarr below the V3 threshold. Hoever it is an optional denpendency. This PR allows users to install zarr via optional dependency to choose between optimal reading and legacy reading.