### PR TITLE
feature/tifffile-support-zarr-3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,11 +36,9 @@ dependencies = [
   "ome-types[lxml]>=0.4.0",
   "pydantic>= 1.10.0",
   "PyYAML>=6.0",
-  "tifffile>=2022.4.22",
+  "tifffile[zarr]>=2025.5.21",
   "xarray>=0.16.1",
   "xmlschema",  # no pin because it's pulled in from OME types
-  #zarr pinned since breaking changes in 3.0 are available with python 3.11
-  "zarr>=2.6,<3.0.0", # for tifffile;
 ]
 
 [project.urls]


### PR DESCRIPTION
### Description 
Tifffile agreed to support Zarr3! so we don't need to choose anymore.