### PR TITLE
raise exceptions instead of return false so user can see WHY it failed

### DIFF
--- a/bioio_ome_tiff/reader.py
+++ b/bioio_ome_tiff/reader.py
@@ -104,23 +104,42 @@ class Reader(reader.Reader):
                     # in this case, because it's not the main file we want to just role
                     # back to TiffReader
                     if ome.binary_only:
-                        return False
-
+                        log.debug(
+                            "The OME metadata indicates this is a binary OME-TIFF. "
+                        )
+                        raise exceptions.UnsupportedFileFormatError(
+                            "bioio-ome-tiff",
+                            path,
+                            "The OME metadata indicates this is a binary OME-TIFF.",
+                        )
                     return True
 
         # tifffile exceptions
-        except (TiffFileError, TypeError):
-            return False
+        except (TiffFileError, TypeError) as e:
+            log.debug(f"Error: {e}")
+            raise exceptions.UnsupportedFileFormatError(
+                "bioio-ome-tiff",
+                path,
+                str(e),
+            )
 
         # xml parse errors
         except ET.ParseError as e:
             log.debug(f"Failed to parse XML for the provided file. Error: {e}")
-            return False
+            raise exceptions.UnsupportedFileFormatError(
+                "bioio-ome-tiff",
+                path,
+                f"Failed to parse XML for the provided file. Error: {e}",
+            )
 
         # invalid OME XMl
         except (XMLSchemaValueError, XMLSchemaValidationError, ValidationError) as e:
             log.debug(f"OME XML validation failed. Error: {e}")
-            return False
+            raise exceptions.UnsupportedFileFormatError(
+                "bioio-ome-tiff",
+                path,
+                f"OME XML validation failed. Error: {e}",
+            )
 
         # cant connect to external schema resource (no internet conection)
         except URLError as e:
@@ -129,11 +148,21 @@ class Reader(reader.Reader):
                 f"(no internet connection). "
                 f"Error: {e}"
             )
-            return False
+            raise exceptions.UnsupportedFileFormatError(
+                "bioio-ome-tiff",
+                path,
+                f"Could not validate OME XML against referenced schema "
+                f"(no internet connection). "
+                f"Error: {e}",
+            )
 
         except Exception as e:
             log.debug(f"Unhandled exception: {e}")
-            return False
+            raise exceptions.UnsupportedFileFormatError(
+                "bioio-ome-tiff",
+                path,
+                str(e),
+            )
 
     @staticmethod
     def _guess_ome_dim_order(tiff: TiffFile, ome: OME, scene_index: int) -> List[str]:
@@ -206,10 +235,7 @@ class Reader(reader.Reader):
         self.clean_metadata = clean_metadata
 
         # Enforce valid image
-        if not self._is_supported_image(self._fs, self._path, clean_metadata):
-            raise exceptions.UnsupportedFileFormatError(
-                self.__class__.__name__, self._path
-            )
+        self._is_supported_image(self._fs, self._path, clean_metadata)
 
         # Get ome-types object and warn of other behaviors
         with self._fs.open(self._path) as open_resource:


### PR DESCRIPTION
### Link to Relevant Issue

This pull request resolves #
https://github.com/bioio-devs/bioio-bioformats/issues/21
### Description of Changes

raise exceptions instead of return false so user can see WHY it failed
Added some log.debug to make flow consistent.
