### PR TITLE
add trivial read/write confirmation

### DIFF
--- a/bioio_ome_tiff/tests/writers/test_ome_tiff_writer.py
+++ b/bioio_ome_tiff/tests/writers/test_ome_tiff_writer.py
@@ -12,7 +12,7 @@ from ome_types import to_xml
 from ome_types.model import OME
 
 from bioio_ome_tiff.writers import OmeTiffWriter
-
+from bioio_ome_tiff import Reader
 from ..conftest import array_constructor
 
 
@@ -96,7 +96,11 @@ def test_ome_tiff_writer_no_meta(
             scene = tiff.series[0]
             assert scene.shape == expected_read_shape
             assert scene.pages.axes == expected_read_dim_order
-
+    open_resource.close()
+    # trivial check to make sure we read what we write
+    reader = Reader(image=path)
+    scenes = reader.scenes
+    assert len(scenes) == 1
 
 @array_constructor
 @pytest.mark.parametrize(
@@ -214,7 +218,10 @@ def test_ome_tiff_writer_with_meta(
             scene = tiff.series[0]
             assert scene.shape == tuple(expected_shape)
             assert scene.pages.axes == expected_dim_order
-
+    # trivial check to make sure we read what we write
+    reader = Reader(image=path)
+    scenes = reader.scenes
+    assert len(scenes) == 1
 
 @pytest.mark.parametrize(
     "array_data, write_dim_order, read_shapes, read_dim_order",

--- a/bioio_ome_tiff/tests/writers/test_ome_tiff_writer.py
+++ b/bioio_ome_tiff/tests/writers/test_ome_tiff_writer.py
@@ -103,6 +103,9 @@ def test_ome_tiff_writer_no_meta(
     scenes = reader.scenes
     if scenes:
         assert len(scenes) == 1
+    assert len(reader.shape) >= (len(expected_read_shape))
+    assert reader.shape[-1] == expected_read_shape[-1]
+    assert reader.shape[-2] == expected_read_shape[-2]
 
 
 @array_constructor
@@ -228,6 +231,9 @@ def test_ome_tiff_writer_with_meta(
     scenes = reader.scenes
     if scenes:
         assert len(scenes) == 1
+    assert len(reader.shape) >= (len(expected_shape))
+    assert reader.shape[-1] == expected_shape[-1]
+    assert reader.shape[-2] == expected_shape[-2]
 
 
 @pytest.mark.parametrize(

--- a/bioio_ome_tiff/tests/writers/test_ome_tiff_writer.py
+++ b/bioio_ome_tiff/tests/writers/test_ome_tiff_writer.py
@@ -224,9 +224,8 @@ def test_ome_tiff_writer_with_meta(
             scene = tiff.series[0]
             assert scene.shape == tuple(expected_shape)
             assert scene.pages.axes == expected_dim_order
+    open_resource.close()
     # trivial check to make sure we read what we write
-    reader = Reader(image=path)
-    scenes = reader.scenes
     reader = Reader(image=path)
     scenes = reader.scenes
     if scenes:

--- a/bioio_ome_tiff/tests/writers/test_ome_tiff_writer.py
+++ b/bioio_ome_tiff/tests/writers/test_ome_tiff_writer.py
@@ -11,8 +11,9 @@ import tifffile
 from ome_types import to_xml
 from ome_types.model import OME
 
-from bioio_ome_tiff.writers import OmeTiffWriter
 from bioio_ome_tiff import Reader
+from bioio_ome_tiff.writers import OmeTiffWriter
+
 from ..conftest import array_constructor
 
 
@@ -100,7 +101,9 @@ def test_ome_tiff_writer_no_meta(
     # trivial check to make sure we read what we write
     reader = Reader(image=path)
     scenes = reader.scenes
-    assert len(scenes) == 1
+    if scenes:
+        assert len(scenes) == 1
+
 
 @array_constructor
 @pytest.mark.parametrize(
@@ -221,7 +224,11 @@ def test_ome_tiff_writer_with_meta(
     # trivial check to make sure we read what we write
     reader = Reader(image=path)
     scenes = reader.scenes
-    assert len(scenes) == 1
+    reader = Reader(image=path)
+    scenes = reader.scenes
+    if scenes:
+        assert len(scenes) == 1
+
 
 @pytest.mark.parametrize(
     "array_data, write_dim_order, read_shapes, read_dim_order",


### PR DESCRIPTION
This pull request resolves #
https://github.com/bioio-devs/bioio-ome-tiff/issues/23

### Description of Changes
Add a simple read after the writes (and lower-level integrity checks) to confirm the reader works with the writer.
When I wrote the original ticket, I was thinking of using BioImage(path) but currently this repo doesn't require bioio, just bioio-base, and the extra reassurance of going upstream of the Reader(path) didn't seem to be worth adding the dependency. 
I'm not entirely sure of the net benefit of this change, since the existing code already tests an almost identical code path, but it is possible for the actual code path to change without updating how this test path.